### PR TITLE
Fix minor spelling mistake

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="http://h.js.org/" />
     <meta property="og:image" content="http://h.js.org/img/h.js.png" />
-    <meta property="og:description" content="Feature - Only 2.0KB (or 1.3KB if gzipepd) - Of cource, self contained - Written in ES2015 - Exact highlighting - Support ES2015 syntax - Support JSDoc tag highlighting - Support UMD" />
+    <meta property="og:description" content="Feature - Only 2.0KB (or 1.3KB if gzipepd) - Of course, self contained - Written in ES2015 - Exact highlighting - Support ES2015 syntax - Support JSDoc tag highlighting - Support UMD" />
     <link rel="stylesheet" href="css/style.css">
 </head>
 


### PR DESCRIPTION
`cource` --> `course`

Don't know if this is even being maintained any more, but I saw a little mistake on h.js.org, and so decided to fix it.

Cheers!